### PR TITLE
Fixed a crash when the image is smaller than screen size

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ allprojects {
 }
 
 dependencies {
-  compile 'com.linecorp:clayview:0.1.0'
+  compile 'com.linecorp:clayview:0.1.1'
 }
 ```
 

--- a/clayview/build.gradle
+++ b/clayview/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka-android'
 
 // This is the library version used when deploying the artifact
-version = "0.1.0"
+version = "0.1.1"
 
 android {
     compileSdkVersion 25
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionCode 1
+        versionCode 2
         versionName version
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/clayview/src/main/java/com/linecorp/clay/graphic/ImageProcessUtils.kt
+++ b/clayview/src/main/java/com/linecorp/clay/graphic/ImageProcessUtils.kt
@@ -63,15 +63,18 @@ fun getPathBoundsArea(path: Path): Int {
  * Get crop image by path
  * @param source Source bitmap
  * @param path Path
+ * @param validRect The valid rect. The outside of valid rect would not be cropped even it is inside the path
  * @param antiAlias enable antiAlias if set true
  * @return New cropped bitmap.
  */
 fun cropImage(source: Bitmap, path: Path, antiAlias: Boolean): Bitmap {
     val selectedRectOnBitmap = getPathBounds(path)
+    val selectedRectWidth = Math.min(selectedRectOnBitmap.width(), source.width)
+    val selectedRectHeight = Math.min(selectedRectOnBitmap.height(), source.height)
     selectedRectOnBitmap.left = Math.max(selectedRectOnBitmap.left, 0)
     selectedRectOnBitmap.top = Math.max(selectedRectOnBitmap.top, 0)
-    selectedRectOnBitmap.right = Math.min(selectedRectOnBitmap.right, source.width)
-    selectedRectOnBitmap.bottom = Math.min(selectedRectOnBitmap.bottom, source.height)
+    selectedRectOnBitmap.right = selectedRectOnBitmap.left + selectedRectWidth
+    selectedRectOnBitmap.bottom = selectedRectOnBitmap.top + selectedRectHeight
     val croppedDstImage = Bitmap.createBitmap(selectedRectOnBitmap.width(),
                                               selectedRectOnBitmap.height(),
                                               Bitmap.Config.ARGB_8888)

--- a/clayview/src/main/java/com/linecorp/clay/view/ClayView.kt
+++ b/clayview/src/main/java/com/linecorp/clay/view/ClayView.kt
@@ -194,7 +194,8 @@ class ClayView : BaseTransformableView {
             bitmap?.let { srcBitmap ->
                 val selectedPathOnBitmap = Path(currentDrawingPath.path)
                 selectedPathOnBitmap.transform(getInvertMatrix(theDisplayMatrix))
-                return cropImage(source = srcBitmap, path = selectedPathOnBitmap, antiAlias = antiAlias)
+                return cropImage(source = srcBitmap, path = selectedPathOnBitmap,
+                                 antiAlias = antiAlias)
             }
         }
         return null


### PR DESCRIPTION
The width or height of the rect of cropped path would become negative in case the bitmap is smaller than screen size. So it would cause a crash when creating the bitmap